### PR TITLE
Fixed the text mode for Select and added 'Vent' to the selection menu

### DIFF
--- a/resources-fre/strings/strings.xml
+++ b/resources-fre/strings/strings.xml
@@ -65,4 +65,8 @@
 	<string id="frunk">Coffre avant</string>
 	<string id="trunk">Valise</string>
 	<string id="port">Port</string>
+	<string id="vent">Ventilé</string>
+	<string id="label_open_vent">Ventiler ?</string>
+	<string id="label_close_vent">Fermer fenêtre ?</string>
+    <string id="label_vent">Ventilé</string>
 </strings>

--- a/resources-swe/strings/strings.xml
+++ b/resources-swe/strings/strings.xml
@@ -65,4 +65,8 @@
 	<string id="frunk">Frunk</string>
 	<string id="trunk">Trunk</string>
 	<string id="port">Port</string>
+	<string id="vent">Vent</string>
+    <string id="label_open_vent">Vent ?</string>
+    <string id="label_close_vent">Close windows ?</string>
+    <string id="label_vent">Ventilé</string>
 </strings>

--- a/resources/layouts/trunksmenu.xml
+++ b/resources/layouts/trunksmenu.xml
@@ -1,5 +1,7 @@
 <menu id="TrunksMenu">
     <menu-item id="frunk" label="@Strings.frunk" />
     <menu-item id="trunk" label="@Strings.trunk" />
-    <menu-item id="port" label="@Strings.port" />
+    <menu-item id="port" label="@Strings.port" /><menu-item id="vent"
+    	label="@Strings.vent">
+</menu-item>
 </menu>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -65,4 +65,8 @@
 	<string id="frunk">Frunk</string>
 	<string id="trunk">Trunk</string>
 	<string id="port">Port</string>
+	<string id="vent">Vent</string>
+    <string id="label_open_vent">Vent ?</string>
+    <string id="label_close_vent">Close windows ?</string>
+    <string id="label_vent">Vent</string>
 </strings>

--- a/source/MainDelegate.mc
+++ b/source/MainDelegate.mc
@@ -31,6 +31,7 @@ class MainDelegate extends Ui.BehaviorDelegate {
     var _unlock;
     var _lock;
     var _settings;
+    var _vent;
 	
     var _data;
 
@@ -45,7 +46,7 @@ class MainDelegate extends Ui.BehaviorDelegate {
         _sleep_timer = new Timer.Timer();
         _handler = handler;
         _tesla = null;
-
+		
         if (_token != null && _token.length() != 0) {
             _need_auth = false;
             _auth_done = true;
@@ -68,6 +69,7 @@ class MainDelegate extends Ui.BehaviorDelegate {
         _unlock = false;
         _lock = false;
 		_bypass_confirmation = false;
+		_vent = false;
 
         stateMachine();
     }
@@ -285,6 +287,34 @@ class MainDelegate extends Ui.BehaviorDelegate {
 	            Ui.pushView(view, delegate, Ui.SLIDE_UP);
 	        }
         }
+
+        if (_vent) {
+            _vent = false;
+            var venting = Application.getApp().getProperty("venting");
+
+            if (venting == 0) {
+	            var view = new Ui.Confirmation(Ui.loadResource(Rez.Strings.label_open_vent));
+	            var delegate = new SimpleConfirmDelegate(method(:openVentConfirmed));
+	            Ui.pushView(view, delegate, Ui.SLIDE_UP);
+            }
+            else {
+	            var view = new Ui.Confirmation(Ui.loadResource(Rez.Strings.label_close_vent));
+	            var delegate = new SimpleConfirmDelegate(method(:closeVentConfirmed));
+	            Ui.pushView(view, delegate, Ui.SLIDE_UP);
+            }
+        }
+    }
+
+    function openVentConfirmed() {
+		_handler.invoke(Ui.loadResource(Rez.Strings.label_vent));
+        Application.getApp().setProperty("venting", 4);
+        _tesla.vent(_vehicle_id, method(:genericHandler), "vent", Application.getApp().getProperty("latitude"), Application.getApp().getProperty("longitude"));
+    }
+
+    function closeVentConfirmed() {
+	    _handler.invoke(Ui.loadResource(Rez.Strings.label_vent));
+        Application.getApp().setProperty("venting", 0);
+        _tesla.vent(_vehicle_id, method(:genericHandler), "close", Application.getApp().getProperty("latitude"), Application.getApp().getProperty("longitude"));
     }
 
     function frunkConfirmed() {
@@ -429,15 +459,15 @@ class MainDelegate extends Ui.BehaviorDelegate {
             _resetToken();
             _handler.invoke(Ui.loadResource(Rez.Strings.label_error) + responseCode.toString());
 
-//            var alert = new Alert({
-//				:timeout => 4000,
-//				:font => Graphics.FONT_TINY,
-//				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
-//				:fgcolor => Graphics.COLOR_RED,
-//				:bgcolor => Graphics.COLOR_WHITE
-//			});
-//			
-//			alert.pushView(Ui.SLIDE_IMMEDIATE);
+            var alert = new Alert({
+				:timeout => 4000,
+				:font => Graphics.FONT_TINY,
+				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
+				:fgcolor => Graphics.COLOR_RED,
+				:bgcolor => Graphics.COLOR_WHITE
+			});
+			
+			alert.pushView(Ui.SLIDE_IMMEDIATE);
         }
     }
 
@@ -461,15 +491,15 @@ class MainDelegate extends Ui.BehaviorDelegate {
                 stateMachine();
             }
 
-//            var alert = new Alert({
-//				:timeout => 4000,
-//				:font => Graphics.FONT_TINY,
-//				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
-//				:fgcolor => Graphics.COLOR_RED,
-//				:bgcolor => Graphics.COLOR_WHITE
-//			});
-//			
-//			alert.pushView(Ui.SLIDE_IMMEDIATE);
+            var alert = new Alert({
+				:timeout => 4000,
+				:font => Graphics.FONT_TINY,
+				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
+				:fgcolor => Graphics.COLOR_RED,
+				:bgcolor => Graphics.COLOR_WHITE
+			});
+			
+			alert.pushView(Ui.SLIDE_IMMEDIATE);
         }
     }
 
@@ -493,15 +523,15 @@ class MainDelegate extends Ui.BehaviorDelegate {
                 }
                 _handler.invoke(Ui.loadResource(Rez.Strings.label_error) + responseCode.toString());
 
-//	            var alert = new Alert({
-//					:timeout => 4000,
-//					:font => Graphics.FONT_TINY,
-//					:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
-//					:fgcolor => Graphics.COLOR_RED,
-//					:bgcolor => Graphics.COLOR_WHITE
-//				});
-//				
-//				alert.pushView(Ui.SLIDE_IMMEDIATE);
+	            var alert = new Alert({
+					:timeout => 4000,
+					:font => Graphics.FONT_TINY,
+					:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
+					:fgcolor => Graphics.COLOR_RED,
+					:bgcolor => Graphics.COLOR_WHITE
+				});
+				
+				alert.pushView(Ui.SLIDE_IMMEDIATE);
             }
         }
     }
@@ -524,15 +554,15 @@ class MainDelegate extends Ui.BehaviorDelegate {
                 _sleep_timer.start(method(:delayedWake), 500, false);
             }
 
-//            var alert = new Alert({
-//				:timeout => 4000,
-//				:font => Graphics.FONT_TINY,
-//				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
-//				:fgcolor => Graphics.COLOR_RED,
-//				:bgcolor => Graphics.COLOR_WHITE
-//			});
-//			
-//			alert.pushView(Ui.SLIDE_IMMEDIATE);
+            var alert = new Alert({
+				:timeout => 4000,
+				:font => Graphics.FONT_TINY,
+				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
+				:fgcolor => Graphics.COLOR_RED,
+				:bgcolor => Graphics.COLOR_WHITE
+			});
+			
+			alert.pushView(Ui.SLIDE_IMMEDIATE);
         }
     }
 
@@ -548,15 +578,15 @@ class MainDelegate extends Ui.BehaviorDelegate {
             }
             _handler.invoke(Ui.loadResource(Rez.Strings.label_error) + responseCode.toString());
             
-//            var alert = new Alert({
-//				:timeout => 4000,
-//				:font => Graphics.FONT_TINY,
-//				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
-//				:fgcolor => Graphics.COLOR_RED,
-//				:bgcolor => Graphics.COLOR_WHITE
-//			});
-//			
-//			alert.pushView(Ui.SLIDE_IMMEDIATE);
+            var alert = new Alert({
+				:timeout => 4000,
+				:font => Graphics.FONT_TINY,
+				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
+				:fgcolor => Graphics.COLOR_RED,
+				:bgcolor => Graphics.COLOR_WHITE
+			});
+			
+			alert.pushView(Ui.SLIDE_IMMEDIATE);
         }
     }
 
@@ -572,15 +602,15 @@ class MainDelegate extends Ui.BehaviorDelegate {
             }
             _handler.invoke(Ui.loadResource(Rez.Strings.label_error) + responseCode.toString());
             
-//            var alert = new Alert({
-//				:timeout => 4000,
-//				:font => Graphics.FONT_TINY,
-//				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
-//				:fgcolor => Graphics.COLOR_RED,
-//				:bgcolor => Graphics.COLOR_WHITE
-//			});
-//			
-//			alert.pushView(Ui.SLIDE_IMMEDIATE);
+            var alert = new Alert({
+				:timeout => 4000,
+				:font => Graphics.FONT_TINY,
+				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
+				:fgcolor => Graphics.COLOR_RED,
+				:bgcolor => Graphics.COLOR_WHITE
+			});
+			
+			alert.pushView(Ui.SLIDE_IMMEDIATE);
         }
     }
 
@@ -595,15 +625,15 @@ class MainDelegate extends Ui.BehaviorDelegate {
             }
             _handler.invoke(Ui.loadResource(Rez.Strings.label_error) + responseCode.toString());
 
-//            var alert = new Alert({
-//				:timeout => 4000,
-//				:font => Graphics.FONT_TINY,
-//				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
-//				:fgcolor => Graphics.COLOR_RED,
-//				:bgcolor => Graphics.COLOR_WHITE
-//			});
-//			
-//			alert.pushView(Ui.SLIDE_IMMEDIATE);
+            var alert = new Alert({
+				:timeout => 4000,
+				:font => Graphics.FONT_TINY,
+				:text => Ui.loadResource(Rez.Strings.label_error) + responseCode.toString() + " " + data.get("error"),
+				:fgcolor => Graphics.COLOR_RED,
+				:bgcolor => Graphics.COLOR_WHITE
+			});
+			
+			alert.pushView(Ui.SLIDE_IMMEDIATE);
         }
     }
 

--- a/source/MainView.mc
+++ b/source/MainView.mc
@@ -125,10 +125,16 @@ class MainView extends Ui.View {
                 var driver_temp = _data._vehicle_data.get("climate_state").get("driver_temp_setting");
 				var max_temp = _data._vehicle_data.get("climate_state").get("max_avail_temp");
 				var min_temp = _data._vehicle_data.get("climate_state").get("min_avail_temp");
+				var latitude = _data._vehicle_data.get("drive_state").get("latitude");
+				var longitude = _data._vehicle_data.get("drive_state").get("longitude");
+			    var venting = _data._vehicle_data.get("vehicle_state").get("fd_window").toNumber() + _data._vehicle_data.get("vehicle_state").get("rd_window").toNumber() + _data._vehicle_data.get("vehicle_state").get("fp_window").toNumber() + _data._vehicle_data.get("vehicle_state").get("rp_window").toNumber();
 				
 	            Application.getApp().setProperty("driver_temp", driver_temp);
 	            Application.getApp().setProperty("max_temp", max_temp);
 	            Application.getApp().setProperty("min_temp", min_temp);
+	            Application.getApp().setProperty("venting", venting);
+	            Application.getApp().setProperty("latitude", latitude);
+	            Application.getApp().setProperty("longitude", longitude);
                 
                 // Draw the charge status
                 dc.setColor(Graphics.COLOR_DK_GREEN, Graphics.COLOR_BLACK);

--- a/source/ServiceDelegate.mc
+++ b/source/ServiceDelegate.mc
@@ -41,6 +41,9 @@ class MyServiceDelegate extends System.ServiceDelegate {
             var battery_level = vehicle_data.get("charge_state").get("battery_level");
             var battery_range = vehicle_data.get("charge_state").get("battery_range");
             var charging_state = vehicle_data.get("charge_state").get("charging_state");
+		    var venting = vehicle_data.get("vehicle_state").get("fd_window").toNumber() + vehicle_data.get("vehicle_state").get("rd_window").toNumber() + vehicle_data.get("vehicle_state").get("fp_window").toNumber() + vehicle_data.get("vehicle_state").get("rp_window").toNumber();
+            Application.getApp().setProperty("venting", venting);
+
             data.put("status", battery_level + "%" + (charging_state.equals("Charging") ? "+" : "") + " / " + battery_range.toNumber() + " @ " + System.getClockTime().hour.format("%d")+":"+System.getClockTime().min.format("%02d"));
             Background.exit(data);
         } else if (responseCode == 408) {

--- a/source/Tesla.mc
+++ b/source/Tesla.mc
@@ -126,4 +126,25 @@ class Tesla {
             notify
         );
     }
+
+    function vent(vehicle, notify, which, lat, lon) {
+        var url = "https://owner-api.teslamotors.com/api/1/vehicles/" + vehicle.toString() + "/command/window_control";
+        Communications.makeWebRequest(
+            url,
+            {
+                "command" => which,
+                "lat" => lat,
+                "lon" => lon
+            },
+            {
+                :method => Communications.HTTP_REQUEST_METHOD_POST,
+                :headers => {
+                    "Authorization" => _token
+                },
+                :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
+            },
+            notify
+        );
+    }
+
 }

--- a/source/TrunksMenu.mc
+++ b/source/TrunksMenu.mc
@@ -1,5 +1,6 @@
 using Toybox.WatchUi as Ui;
 
+
 class TrunksMenuDelegate extends Ui.MenuInputDelegate {
     var _controller;
 	
@@ -17,6 +18,8 @@ class TrunksMenuDelegate extends Ui.MenuInputDelegate {
         	_controller._bypass_confirmation = true;
         } else if (item == :port) {
         	_controller._open_port = true;
+        } else if (item == :vent) {
+        	_controller._vent = true;
         }
 
         _controller.stateMachine();


### PR DESCRIPTION
Vent has the following caveat:

1. I tried to use Menu2 to have dynamic menus which would display "Vent" or "Close windows" based on the current windows state, but I'm not familiar enough with that API to get it to work :-( So instead of a dynamic menu, it's static ("Vent") and when you select it, it does a SimpleConfirmDelegate with "Vent" or "Close windows" so you know beforehand its current state and the right command is called.

2. If you use another app to vent or close the windows while the widget is running, unless you do something that makes the screen refresh (like lock/unlock the doors), it won't know the windows have changed state.
